### PR TITLE
Add follow-up post: Fixing My JSON-LD, Two Years Later

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,13 @@
 import alpinejs from '@astrojs/alpinejs';
+import { unified } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, fontProviders } from 'astro/config';
 import expressiveCode from 'astro-expressive-code';
-
 // Load environment variables
 import { config } from 'dotenv';
+import { remarkAlert } from 'remark-github-blockquote-alert';
 
 config();
 
@@ -35,6 +36,11 @@ export default defineConfig({
   },
   build: {
     inlineStylesheets: 'always',
+  },
+  markdown: {
+    processor: unified({
+      remarkPlugins: [remarkAlert],
+    }),
   },
   site: 'https://www.joshfinnie.com/',
   trailingSlash: 'always',

--- a/cloudinary-mapping.json
+++ b/cloudinary-mapping.json
@@ -1,11 +1,11 @@
 {
-  "uploadedAt": "2026-08-07T15:17:55.853Z",
+  "uploadedAt": "2026-08-28T18:03:08.868Z",
   "cloudName": "dgd9cw3gu",
   "images": [
     {
-      "localPath": "src/assets/blog/starlink-rural-broadband-grift.jpg",
-      "publicId": "blog/starlink-rural-broadband-grift",
-      "cloudinaryUrl": "https://res.cloudinary.com/dgd9cw3gu/image/upload/v1786115875/blog/starlink-rural-broadband-grift.jpg"
+      "localPath": "src/assets/blog/fixing-my-json-ld-two-years-later.jpg",
+      "publicId": "blog/fixing-my-json-ld-two-years-later",
+      "cloudinaryUrl": "https://res.cloudinary.com/dgd9cw3gu/image/upload/v1787940187/blog/fixing-my-json-ld-two-years-later.jpg"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@astrojs/alpinejs": "^1.0.0",
     "@astrojs/check": "^0.9.10",
+    "@astrojs/markdown-remark": "^7.2.4",
     "@astrojs/mdx": "7.0.5",
     "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",
@@ -49,6 +50,7 @@
     "github-slugger": "^2.0.0",
     "lodash.kebabcase": "^4.1.1",
     "mermaid": "^11.16.1",
+    "remark-github-blockquote-alert": "^2.1.0",
     "sharp": "^0.35.3",
     "shorthash": "^0.0.2",
     "tailwind-merge": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,12 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@6.0.3)
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.4
+        version: 7.2.4
       '@astrojs/mdx':
         specifier: 7.0.5
-        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
+        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
       '@astrojs/rss':
         specifier: ^4.0.19
         version: 4.0.19
@@ -54,16 +57,16 @@ importers:
         version: 3.15.12
       astro:
         specifier: 7.1.6
-        version: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
+        version: 7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
       astro-cloudinary:
         specifier: ^1.4.0
-        version: 1.4.0(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))(jiti@2.7.0)(postcss@8.5.25)(typescript@6.0.3)(yaml@2.9.0)
+        version: 1.4.0(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))(jiti@2.7.0)(postcss@8.5.25)(typescript@6.0.3)(yaml@2.9.0)
       astro-expressive-code:
         specifier: ^0.44.1
-        version: 0.44.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
+        version: 0.44.1(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
       astro-og-canvas:
         specifier: ^0.13.0
-        version: 0.13.0(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
+        version: 0.13.0(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -85,6 +88,9 @@ importers:
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1
+      remark-github-blockquote-alert:
+        specifier: ^2.1.0
+        version: 2.1.0
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.1.2)
@@ -216,6 +222,9 @@ packages:
   '@astrojs/internal-helpers@0.10.2':
     resolution: {integrity: sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==}
 
+  '@astrojs/internal-helpers@0.10.4':
+    resolution: {integrity: sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==}
+
   '@astrojs/language-server@2.16.13':
     resolution: {integrity: sha512-ekOa+CYprEq5n4EJC1qTIAhLk49HZIUQuFwrEuF+3JK/pdMaYnWoREFUI2A0KEPOJiFA2kamBzKzbYljDvUxLg==}
     hasBin: true
@@ -230,6 +239,9 @@ packages:
 
   '@astrojs/markdown-remark@7.2.2':
     resolution: {integrity: sha512-FGfmK84zSNcrsBd0dl1gXE9JvZYElp8EXQa2jpHVAxG4deGKAp43wspxFupjADJX7MSsMRHwYCnfT6EyVmgeFQ==}
+
+  '@astrojs/markdown-remark@7.2.4':
+    resolution: {integrity: sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow==}
 
   '@astrojs/markdown-satteri@0.3.5':
     resolution: {integrity: sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==}
@@ -2937,6 +2949,10 @@ packages:
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
+  remark-github-blockquote-alert@2.1.0:
+    resolution: {integrity: sha512-J392jmIP684d7iGsENN0uguL10IGbRdc8bTUSrd/jOLzdWkwg721Fj3JPQGN8tF6fTIrE5HHOIA3nBuwuaeuPQ==}
+    engines: {node: '>=16'}
+
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
@@ -3664,6 +3680,17 @@ snapshots:
       smol-toml: 1.7.1
       unified: 11.0.5
 
+  '@astrojs/internal-helpers@0.10.4':
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      js-yaml: 4.3.1
+      picomatch: 4.0.5
+      retext-smartypants: 6.2.0
+      shiki: 4.4.1
+      smol-toml: 1.7.1
+      unified: 11.0.5
+
   '@astrojs/language-server@2.16.13(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
@@ -3712,6 +3739,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@astrojs/markdown-remark@7.2.4':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.4
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.3
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@astrojs/markdown-satteri@0.3.5':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
@@ -3720,13 +3769,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))':
+  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/markdown-remark': 7.2.2
       '@mdx-js/mdx': 3.1.1
       acorn: 8.18.0
-      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
       es-module-lexer: 2.3.1
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4788,12 +4837,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@unpic/astro@0.0.47(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))':
+  '@unpic/astro@0.0.47(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))':
     dependencies:
       '@unpic/core': 0.0.49
       '@unpic/pixels': 1.3.0
       '@unpic/placeholder': 0.1.2
-      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
       blurhash: 2.0.5
 
   '@unpic/core@0.0.49':
@@ -4929,15 +4978,15 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-cloudinary@1.4.0(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))(jiti@2.7.0)(postcss@8.5.25)(typescript@6.0.3)(yaml@2.9.0):
+  astro-cloudinary@1.4.0(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))(jiti@2.7.0)(postcss@8.5.25)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       '@cloudinary-util/types': 1.6.0
       '@cloudinary-util/url-loader': 6.2.0
       '@cloudinary-util/util': 4.2.0
       '@cloudinary/url-gen': 1.22.0
-      '@unpic/astro': 0.0.47(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
+      '@unpic/astro': 0.0.47(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0))
       '@unpic/core': 0.0.49
-      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
       tsup: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(typescript@6.0.3)(yaml@2.9.0)
       unpic: 3.22.0
     transitivePeerDependencies:
@@ -4950,20 +4999,20 @@ snapshots:
       - typescript
       - yaml
 
-  astro-expressive-code@0.44.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)):
+  astro-expressive-code@0.44.1(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)):
     dependencies:
-      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
 
-  astro-og-canvas@0.13.0(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)):
+  astro-og-canvas@0.13.0(astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)):
     dependencies:
-      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0)
       canvaskit-wasm: 0.41.1
       deterministic-object-hash: 2.0.2
       entities: 8.0.0
 
-  astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0):
+  astro@7.1.6(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.2
@@ -5019,7 +5068,7 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.2
+      '@astrojs/markdown-remark': 7.2.4
       sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6769,6 +6818,10 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-github-blockquote-alert@2.1.0:
+    dependencies:
+      unist-util-visit: 5.1.0
 
   remark-mdx@3.1.1:
     dependencies:

--- a/src/collections/blog/adding-json-ld-to-my-website.mdx
+++ b/src/collections/blog/adding-json-ld-to-my-website.mdx
@@ -16,6 +16,9 @@ I have been working pretty hard on the [SEO](https://en.wikipedia.org/wiki/Searc
 I constantly use the [Google Search Cental](https://developers.google.com/search) to improve my reach.
 And recently, I found another one of their tools to add to my skillset: JSON-LD.
 
+> [!TIP]
+> I revisited this setup two years later and found a couple of real bugs hiding in it. Read the [update, with more depth and the actual fixes](/blog/fixing-my-json-ld-two-years-later/).
+
 ## What is JSON-LD?
 
 Per [Wikipedia](https://en.wikipedia.org/wiki/JSON-LD) JSON-LD is a method of encoding linked data using JSON.

--- a/src/collections/blog/fixing-my-json-ld-two-years-later.md
+++ b/src/collections/blog/fixing-my-json-ld-two-years-later.md
@@ -33,7 +33,53 @@ I'd read [Stephen Lunt's post on structured data in Astro](https://stephen-lunt.
 </head>
 ```
 
-Blog posts, notes, and anything else that's an article now share one `ArticleStructuredData` component instead of each maintaining its own copy of the same shape:
+Blog posts, notes, and anything else that's an article now share one `ArticleStructuredData` component instead of each maintaining its own copy of the same shape. This is the component itself, not just where it gets called:
+
+```astro
+---
+import { getCloudinaryImageUrl } from '@lib/cloudinary';
+
+interface Props {
+  headline: string;
+  description: string;
+  date: string;
+  url: string;
+  tags?: string[];
+  heroImage?: string | undefined;
+  articleType?: 'BlogPosting' | 'TechArticle';
+  isPartOf?: string;
+}
+
+const { headline, description, date, url, tags = [], heroImage, articleType = 'BlogPosting', isPartOf } = Astro.props;
+
+const image = heroImage ? getCloudinaryImageUrl(heroImage, { width: 1024 }) : undefined;
+
+const schema = JSON.stringify({
+  '@context': 'https://schema.org/',
+  '@type': articleType,
+  headline,
+  author: {
+    '@type': 'Person',
+    name: 'Josh Finnie',
+  },
+  datePublished: date,
+  dateCreated: date,
+  dateModified: date,
+  description,
+  url,
+  ...(image ? { image } : {}),
+  ...(isPartOf ? { isPartOf: { '@type': 'BlogPosting', url: isPartOf } } : {}),
+  inLanguage: 'en-US',
+  keywords: tags,
+});
+---
+
+<script type="application/ld+json" set:html={schema} is:inline />
+```
+
+`articleType` defaults to `BlogPosting`, which covers regular posts and notes, but I also render tutorial series parts through this same component with `articleType="TechArticle"` and `isPartOf` pointing back at the series' landing page. `heroImage` and `isPartOf` are both optional, and the spread-with-a-conditional (`...(image ? { image } : {})`) is how they skip showing up in the JSON at all when a page doesn't have one, rather than serializing as `"image": undefined` or `null`.
+
+A page that has all of that just calls it once:
 
 ```astro
 <BaseLayout ...>
@@ -52,7 +98,33 @@ Blog posts, notes, and anything else that's an article now share one `ArticleStr
 </BaseLayout>
 ```
 
-Generic pages, my about page, my uses page, got the same treatment with a `WebPageStructuredData` component, which is also where that object-wrapping bug finally got caught and fixed.
+Generic pages, my about page, my uses page, got the same treatment with a `WebPageStructuredData` component. This is also where that object-wrapping bug actually got caught and fixed, so here's the whole thing, bug fix included:
+
+```astro
+---
+interface Props {
+  title: string;
+  description: string;
+}
+
+const { title, description } = Astro.props;
+
+const schema = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: title,
+  description,
+  author: {
+    '@type': 'Person',
+    name: 'Josh Finnie',
+  },
+});
+---
+
+<script type="application/ld+json" set:html={schema} is:inline />
+```
+
+`name: title` instead of `name: { title }`. That's the entire fix, a pair of braces removed, and a different JSON shape in the output.
 
 The real win isn't the slot itself. It's that there's now exactly one place that knows what a `BlogPosting` schema looks like, and one place that knows what a `WebPage` schema looks like, so a fix or an improvement happens once instead of getting silently missed in whichever of six components I didn't think to update. That's the difference between "I added JSON-LD" and "I have JSON-LD I can actually maintain."
 

--- a/src/collections/blog/fixing-my-json-ld-two-years-later.md
+++ b/src/collections/blog/fixing-my-json-ld-two-years-later.md
@@ -1,0 +1,61 @@
+---
+title: "Fixing My JSON-LD, Two Years Later"
+date: "2026-08-28"
+tags:
+  - "SEO"
+  - "json-ld"
+  - "astro"
+  - "tutorial"
+slug: "fixing-my-json-ld-two-years-later"
+heroImage: "blog/fixing-my-json-ld-two-years-later"
+unsplash: "Alain Pham"
+unsplashURL: "alain_pham"
+description: "Revisiting the JSON-LD I added to this site two years ago, finding two real bugs hiding in it, and moving to a slot-based pattern inspired by Stephen Lunt's Astro structured data post."
+---
+
+Two years ago I wrote about [adding JSON-LD to this blog](/blog/adding-json-ld-to-my-blog/): a `WebSite` schema on every page, a `BlogPosting` schema on every post, a `WebPage` schema on everything else. It worked, and I forgot about it, which is often a sign something is fine. This time it wasn't.
+
+I came back to it while building out a new tutorial series, and revisiting the code from two years ago was a little humbling. Every page on the site was hand-rolling its own `JSON.stringify` block, copied and adjusted slightly for each content type. That copying had let two real bugs creep in without me noticing.
+
+My `BlogPosting` schema's `url` field was missing the `/blog/` prefix and the trailing slash, quietly pointing at a URL that never actually resolved. And the `WebPage` schema snippet I shared in that old post, `"name": {title}`, wasn't just documentation shorthand the way I intended it to read. I had genuinely copied it into real Astro frontmatter exactly like that, where `{title}` is valid JavaScript, just not the JavaScript I meant. It's object shorthand syntax, so instead of the string value of `title`, the schema was shipping `{"name":{"title":"..."}}`, a nested object where a plain string belonged. Neither bug broke the page. They just quietly broke the schema, which is exactly the kind of mistake that's easy to ship and hard to notice, since nothing in the actual rendered page ever tells you your structured data is wrong.
+
+## A Better Pattern
+
+I'd read [Stephen Lunt's post on structured data in Astro](https://stephen-lunt.dev/blog/astro-structured-data/) a while before this, and his approach stuck with me: dedicated components per schema type, injected into the layout through a named slot, instead of scattering the same `JSON.stringify` shape inline across every component that happens to render an article. That's the pattern I moved to.
+
+`BaseLayout` now exposes a `structured-data` slot in its `<head>`, alongside a `WebsiteStructuredData` component that renders unconditionally on every page:
+
+```astro
+<head>
+  <BaseHead ... />
+  <WebsiteStructuredData />
+  <slot name="structured-data" />
+</head>
+```
+
+Blog posts, notes, and anything else that's an article now share one `ArticleStructuredData` component instead of each maintaining its own copy of the same shape:
+
+```astro
+<BaseLayout ...>
+  <ArticleStructuredData
+    slot="structured-data"
+    headline={post.data.title}
+    description={post.data.description}
+    date={post.data.date}
+    url={`https://www.joshfinnie.com/blog/${post.id}/`}
+    tags={post.data.tags}
+    heroImage={post.data.heroImage}
+  />
+  <BlogPost {...post.data} id={post.id}>
+    <Content />
+  </BlogPost>
+</BaseLayout>
+```
+
+Generic pages, my about page, my uses page, got the same treatment with a `WebPageStructuredData` component, which is also where that object-wrapping bug finally got caught and fixed.
+
+The real win isn't the slot itself. It's that there's now exactly one place that knows what a `BlogPosting` schema looks like, and one place that knows what a `WebPage` schema looks like, so a fix or an improvement happens once instead of getting silently missed in whichever of six components I didn't think to update. That's the difference between "I added JSON-LD" and "I have JSON-LD I can actually maintain."
+
+If you're setting this up for the first time, [my original post](/blog/adding-json-ld-to-my-blog/) still covers what JSON-LD is and why it's worth doing. Consider this the sequel: the same idea, with the sharp edges I only found by living with it for two years.
+
+Find me on [**Bluesky**](https://bsky.app/profile/joshfinnie.dev) if you've run into similar rot in your own structured data, or if you want to talk through the slot pattern.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -179,3 +179,66 @@ article > main[role="main"] a[href^="http"]:not([href*="joshfinnie.com"])::after
   -webkit-mask-size: contain;
   mask-size: contain;
 }
+
+/* GitHub-style markdown alerts, written as `> [!TIP] ...` in post source and
+   expanded by remark-github-blockquote-alert. Only `tip` is styled for now:
+   it's the one we use for asides that are useful context but not required
+   reading. The plugin's own icon is masked out and replaced with a
+   lighthouse via mask-image so it inherits the accent color in both themes,
+   same technique as the external-link icon above. */
+.markdown-alert {
+  margin: 2em 0;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-lg);
+  border-width: 1px;
+}
+
+.markdown-alert > :last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  margin-bottom: 0.5rem !important;
+}
+
+.markdown-alert-title .octicon {
+  display: none;
+}
+
+.markdown-alert-title::before {
+  content: "";
+  display: inline-block;
+  width: 1.15em;
+  height: 1.15em;
+  flex: none;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M24 0v24H0V0zM12.593 23.258l-.011.002-.071.035-.02.004-.014-.004-.071-.035c-.01-.004-.019-.001-.024.005l-.004.01-.017.428.005.02.01.013.104.074.015.004.012-.004.104-.074.012-.016.004-.017-.017-.427c-.002-.01-.009-.017-.017-.018m.265-.113-.013.002-.185.093-.01.01-.003.011.018.43.005.012.008.007.201.093c.012.004.023 0 .029-.008l.004-.014-.034-.614c-.003-.012-.01-.02-.02-.022m-.715.002a.023.023 0 0 0-.027.006l-.006.014-.034.614c0 .012.007.02.017.024l.015-.002.201-.093.01-.008.004-.011.017-.43-.003-.012-.01-.01z'/%3E%3Cpath fill='%2309244B' fill-rule='nonzero' d='M12 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2'/%3E%3Cpath fill='%2309244B' d='m12.832 2.353 2.516 1.677c.39.26.636.687.665 1.155l.241 3.847a1 1 0 0 1 .118 1.896L16.94 20H19a1 1 0 1 1 0 2H5a1 1 0 1 1 0-2h2.06l.568-9.072a1 1 0 0 1 .118-1.896l.24-3.847a1.5 1.5 0 0 1 .666-1.155l2.516-1.677a1.5 1.5 0 0 1 1.664 0M14.373 11H9.627l-.563 9h5.871zM4.293 8.293a1 1 0 0 1 1.497 1.32l-.083.094-1 1a1 1 0 0 1-1.497-1.32l.083-.094zm14 0a1 1 0 0 1 1.32-.083l.094.083 1 1a1 1 0 0 1-1.32 1.497l-.094-.083-1-1a1 1 0 0 1 0-1.414M12 4.202 9.967 5.557 9.752 9h4.496l-.215-3.443zm-7.293.09 1 1a1 1 0 0 1-1.414 1.415l-1-1a1 1 0 0 1 1.414-1.414Zm16 0a1 1 0 0 1 0 1.415l-1 1a1 1 0 1 1-1.414-1.414l1-1a1 1 0 0 1 1.414 0Z'/%3E%3C/g%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M24 0v24H0V0zM12.593 23.258l-.011.002-.071.035-.02.004-.014-.004-.071-.035c-.01-.004-.019-.001-.024.005l-.004.01-.017.428.005.02.01.013.104.074.015.004.012-.004.104-.074.012-.016.004-.017-.017-.427c-.002-.01-.009-.017-.017-.018m.265-.113-.013.002-.185.093-.01.01-.003.011.018.43.005.012.008.007.201.093c.012.004.023 0 .029-.008l.004-.014-.034-.614c-.003-.012-.01-.02-.02-.022m-.715.002a.023.023 0 0 0-.027.006l-.006.014-.034.614c0 .012.007.02.017.024l.015-.002.201-.093.01-.008.004-.011.017-.43-.003-.012-.01-.01z'/%3E%3Cpath fill='%2309244B' fill-rule='nonzero' d='M12 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2'/%3E%3Cpath fill='%2309244B' d='m12.832 2.353 2.516 1.677c.39.26.636.687.665 1.155l.241 3.847a1 1 0 0 1 .118 1.896L16.94 20H19a1 1 0 1 1 0 2H5a1 1 0 1 1 0-2h2.06l.568-9.072a1 1 0 0 1 .118-1.896l.24-3.847a1.5 1.5 0 0 1 .666-1.155l2.516-1.677a1.5 1.5 0 0 1 1.664 0M14.373 11H9.627l-.563 9h5.871zM4.293 8.293a1 1 0 0 1 1.497 1.32l-.083.094-1 1a1 1 0 0 1-1.497-1.32l.083-.094zm14 0a1 1 0 0 1 1.32-.083l.094.083 1 1a1 1 0 0 1-1.32 1.497l-.094-.083-1-1a1 1 0 0 1 0-1.414M12 4.202 9.967 5.557 9.752 9h4.496l-.215-3.443zm-7.293.09 1 1a1 1 0 0 1-1.414 1.415l-1-1a1 1 0 0 1 1.414-1.414Zm16 0a1 1 0 0 1 0 1.415l-1 1a1 1 0 1 1-1.414-1.414l1-1a1 1 0 0 1 1.414 0Z'/%3E%3C/g%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.markdown-alert-tip {
+  background-color: var(--color-amber-50);
+  border-color: var(--color-amber-200);
+}
+
+.markdown-alert-tip .markdown-alert-title {
+  color: var(--color-amber-700);
+}
+
+.dark .markdown-alert-tip {
+  background-color: --alpha(var(--color-amber-400) / 10%);
+  border-color: --alpha(var(--color-amber-400) / 30%);
+}
+
+.dark .markdown-alert-tip .markdown-alert-title {
+  color: var(--color-amber-400);
+}

--- a/standard-mapping.json
+++ b/standard-mapping.json
@@ -70,6 +70,7 @@
     "/blog/full-stack-rust-part-1/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mnaggggjxf2o",
     "/blog/font-awesome-is-awesome/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mncsu2wste25",
     "/blog/flat-flog-an-introduction/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mncsu3bns72w",
+    "/blog/fixing-my-json-ld-two-years-later/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mu5xcynlli2r",
     "/blog/first-post/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mncsu3li422m",
     "/blog/building-a-cozy-terminal-fire-in-rust/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mnagghfo2g2c",
     "/blog/fastapi-and-react-in-2025/": "at://did:plc:4po2afnpxgpdwpsr5fwgw3we/site.standard.document/3mnaggho2gy27",


### PR DESCRIPTION
## Summary
- New post revisiting the 2024 JSON-LD post, written up after refactoring the site's structured data to a shared-component, named-slot pattern
- Covers two real bugs the refactor caught: a missing `/blog/` prefix + trailing slash in the `BlogPosting` schema's `url`, and a `WebPage` schema that was literally shipping `{"name":{"title":"..."}}` instead of a plain string
- Credits Stephen Lunt's post on structured data in Astro (https://stephen-lunt.dev/blog/astro-structured-data/) as the inspiration for the slot-based pattern
- Links back to the original post rather than editing it in place

## Test plan
- [ ] `pnpm astro check`, `pnpm build` pass (verified locally, 352 pages)
- [ ] Vale prose lint clean
- [ ] Spot-check the post renders, hero image + attribution correct, both internal links resolve to the original post
- [ ] Confirm the post's own `BlogPosting` JSON-LD is well-formed (verified locally)